### PR TITLE
Add 5S audit flask app example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+instance/
+*.db
+.DS_Store

--- a/5s_audit_app/README.md
+++ b/5s_audit_app/README.md
@@ -1,0 +1,25 @@
+# 5S Audit App
+
+This is a simple Flask application for managing 5S audits in a factory. It allows you to:
+
+- Create audits with checklist items and scores
+- Attach photos before corrective actions with due dates
+- Upload photos after corrective actions
+- Track area zone and status of each audit
+- View a dashboard of all audits
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Open your browser to `http://localhost:5000`.
+
+The database is automatically created on first run, and uploaded files are stored
+in the `static/uploads/` folder.
+The SQLite file `audits.db` will appear in the app directory.

--- a/5s_audit_app/app.py
+++ b/5s_audit_app/app.py
@@ -1,0 +1,91 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+import os
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///audits.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
+
+db = SQLAlchemy(app)
+
+
+class Audit(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    area_zone = db.Column(db.String(100))
+    checklist = db.Column(db.Text)
+    score = db.Column(db.Integer)
+    corrective_required = db.Column(db.Boolean, default=False)
+    photo_before = db.Column(db.String(200))
+    due_date = db.Column(db.Date)
+    photo_after = db.Column(db.String(200))
+    status = db.Column(db.String(20), default='Open')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def create_tables():
+    """Create database tables if they don't exist."""
+    with app.app_context():
+        db.create_all()
+
+
+@app.route('/')
+def index():
+    audits = Audit.query.order_by(Audit.created_at.desc()).all()
+    return render_template('index.html', audits=audits)
+
+
+@app.route('/audit/new', methods=['GET', 'POST'])
+def new_audit():
+    if request.method == 'POST':
+        area_zone = request.form['area_zone']
+        checklist = request.form['checklist']
+        score = request.form.get('score', type=int)
+        corrective_required = 'corrective_required' in request.form
+        due_date = request.form.get('due_date')
+        status = request.form.get('status', 'Open')
+        photo_before_file = request.files.get('photo_before')
+        photo_before_filename = None
+        if photo_before_file and photo_before_file.filename:
+            photo_before_filename = datetime.utcnow().strftime('%Y%m%d%H%M%S_') + photo_before_file.filename
+            save_path = os.path.join(app.config['UPLOAD_FOLDER'], photo_before_filename)
+            os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+            photo_before_file.save(save_path)
+        audit = Audit(
+            area_zone=area_zone,
+            checklist=checklist,
+            score=score,
+            corrective_required=corrective_required,
+            due_date=datetime.strptime(due_date, '%Y-%m-%d').date() if due_date else None,
+            photo_before=photo_before_filename,
+            status=status,
+        )
+        db.session.add(audit)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('new_audit.html')
+
+
+@app.route('/audit/<int:audit_id>', methods=['GET', 'POST'])
+def audit_detail(audit_id):
+    audit = Audit.query.get_or_404(audit_id)
+    if request.method == 'POST':
+        status = request.form.get('status')
+        audit.status = status
+        if 'photo_after' in request.files:
+            photo_after_file = request.files['photo_after']
+            if photo_after_file and photo_after_file.filename:
+                photo_after_filename = datetime.utcnow().strftime('%Y%m%d%H%M%S_') + photo_after_file.filename
+                save_path = os.path.join(app.config['UPLOAD_FOLDER'], photo_after_filename)
+                os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+                photo_after_file.save(save_path)
+                audit.photo_after = photo_after_filename
+        db.session.commit()
+        return redirect(url_for('audit_detail', audit_id=audit.id))
+    return render_template('audit_detail.html', audit=audit)
+
+
+if __name__ == '__main__':
+    create_tables()
+    app.run(debug=True, host='0.0.0.0')

--- a/5s_audit_app/requirements.txt
+++ b/5s_audit_app/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/5s_audit_app/templates/audit_detail.html
+++ b/5s_audit_app/templates/audit_detail.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Audit Detail</h2>
+<table class="table table-bordered">
+  <tr><th>ID</th><td>{{ audit.id }}</td></tr>
+  <tr><th>Area Zone</th><td>{{ audit.area_zone }}</td></tr>
+  <tr><th>Checklist</th><td>{{ audit.checklist }}</td></tr>
+  <tr><th>Score</th><td>{{ audit.score }}</td></tr>
+  <tr><th>Status</th><td>{{ audit.status }}</td></tr>
+  <tr><th>Due Date</th><td>{{ audit.due_date }}</td></tr>
+  <tr>
+    <th>Photo Before</th>
+    <td>
+      {% if audit.photo_before %}
+      <img src="{{ url_for('static', filename='uploads/' + audit.photo_before) }}" class="img-fluid" style="max-width:200px">
+      {% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Photo After</th>
+    <td>
+      {% if audit.photo_after %}
+      <img src="{{ url_for('static', filename='uploads/' + audit.photo_after) }}" class="img-fluid" style="max-width:200px">
+      {% endif %}
+    </td>
+  </tr>
+</table>
+<form method="post" enctype="multipart/form-data" class="mb-3">
+  <div class="mb-3">
+    <label class="form-label">Update Status</label>
+    <select name="status" class="form-select">
+      <option value="Open" {% if audit.status=='Open' %}selected{% endif %}>Open</option>
+      <option value="Closed" {% if audit.status=='Closed' %}selected{% endif %}>Closed</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Photo After</label>
+    <input type="file" name="photo_after" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">Update</button>
+</form>
+<a href="{{ url_for('index') }}" class="btn btn-secondary">Back</a>
+{% endblock %}

--- a/5s_audit_app/templates/base.html
+++ b/5s_audit_app/templates/base.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>5S Audit App</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">5S Audit</a>
+      </div>
+    </nav>
+    <div class="container">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <div class="alert alert-info">{{ messages[0] }}</div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/5s_audit_app/templates/index.html
+++ b/5s_audit_app/templates/index.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<a href="{{ url_for('new_audit') }}" class="btn btn-primary mb-3">New Audit</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Area Zone</th>
+      <th>Score</th>
+      <th>Status</th>
+      <th>Due Date</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for audit in audits %}
+    <tr>
+      <td>{{ audit.id }}</td>
+      <td>{{ audit.area_zone }}</td>
+      <td>{{ audit.score }}</td>
+      <td>{{ audit.status }}</td>
+      <td>{{ audit.due_date }}</td>
+      <td><a class="btn btn-sm btn-secondary" href="{{ url_for('audit_detail', audit_id=audit.id) }}">View</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/5s_audit_app/templates/new_audit.html
+++ b/5s_audit_app/templates/new_audit.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Audit</h2>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">Area Zone</label>
+    <input type="text" name="area_zone" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Checklist</label>
+    <textarea name="checklist" class="form-control" required></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Score</label>
+    <input type="number" name="score" class="form-control" required>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" value="1" name="corrective_required" id="corrective_required">
+    <label class="form-check-label" for="corrective_required">Corrective Required</label>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Due Date</label>
+    <input type="date" name="due_date" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Photo Before</label>
+    <input type="file" name="photo_before" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="Open">Open</option>
+      <option value="Closed">Closed</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a simple Flask app for factory 5S audits
- include dashboard, audit creation and update pages
- allow attachments before and after corrective actions
- document setup instructions
- fix database creation for Flask 3

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m flask --version`


------
https://chatgpt.com/codex/tasks/task_e_684402b6b334832b84aad310a0f0d360